### PR TITLE
🐛 fix(pnpm): added pre-build permissions for eslint to package.json (re #44)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
 	"main": "lib/index.js",
 	"name": "@benjymoses/bootstrap",
 	"packageManager": "pnpm@10.12.4",
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"esbuild"
+		]
+	},
 	"publishConfig": {
 		"access": "public",
 		"registry": "https://registry.npmjs.org/"

--- a/templates/ts/basics/package.json.hbs
+++ b/templates/ts/basics/package.json.hbs
@@ -24,6 +24,11 @@
     "commitlint": {
         "extends": ["gitmoji"]
     },
+    "pnpm": {
+		"onlyBuiltDependencies": [
+			"esbuild"
+		]
+	},
     "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "commitizen": "^4.3.1",


### PR DESCRIPTION
Added package.json configuration to automatically allow esbuild post-install script.

Closes #44